### PR TITLE
Remove routing_api from CC clock too

### DIFF
--- a/remove-routing-components-for-transition.yml
+++ b/remove-routing-components-for-transition.yml
@@ -17,6 +17,9 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/routing_api
 
 - type: remove
+  path: /instance_groups/name=cc-clock/jobs/name=cloud_controller_clock/properties/routing_api
+
+- type: remove
   path: /instance_groups/name=router/jobs/name=gorouter/properties/routing_api
 
 - type: remove


### PR DESCRIPTION
I suspect these properties are actually unused by
cc-clock but it's still confusing to leave them in
when routing-api should be disabled