### PR TITLE
Remove diego_locket_client variable

### DIFF
--- a/remove-routing-components-for-transition.yml
+++ b/remove-routing-components-for-transition.yml
@@ -30,3 +30,6 @@
 
 - type: remove
   path: /variables/name=uaa_clients_routing_api_client_secret
+
+- type: remove
+  path: /variables/name=diego_locket_client


### PR DESCRIPTION
- only used by the 'routing-api' job  https://github.com/cloudfoundry/cf-deployment/blob/b21cdc72b659f85a007d1f18f801ede6c42aa39c/cf-deployment.yml#L769-L771