### PR TITLE
Drop remove of cni job now that it's unused upstream.

### DIFF
--- a/remove-cf-networking-for-transition.yml
+++ b/remove-cf-networking-for-transition.yml
@@ -14,6 +14,9 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden-cni
 
 - type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni
+
+- type: remove
   path: /instance_groups/name=diego-cell/jobs/name=netmon
 
 - type: remove
@@ -21,9 +24,6 @@
 
 - type: remove
   path: /instance_groups/name=diego-cell/jobs/name=silk-daemon
-
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=cni
 
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=silk-controller


### PR DESCRIPTION
We're still using a few opsfiles in this repo, including `remove-cf-networking-for-transition.yml`. As of cf-deployment 2.0, a few jobs in `diego-cell` got renamed. This patch updates the cf networking opsfile with the latest names. Hopefully we'll get around to enabling cf networking soon and not need this opsfile anymore 🤞 