### PR TITLE
Revert "Drop remove of cni job now that it's unused upstream."

### DIFF
--- a/remove-cf-networking-for-transition.yml
+++ b/remove-cf-networking-for-transition.yml
@@ -14,9 +14,6 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden-cni
 
 - type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=silk-cni
-
-- type: remove
   path: /instance_groups/name=diego-cell/jobs/name=netmon
 
 - type: remove
@@ -24,6 +21,9 @@
 
 - type: remove
   path: /instance_groups/name=diego-cell/jobs/name=silk-daemon
+
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=cni
 
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=silk-controller


### PR DESCRIPTION
Reverts cloudfoundry/cf-deployment-transition#9