### PR TITLE
Remove consul reference as Consul is deprecated in CF 5

### DIFF
--- a/remove-routing-components-for-transition.yml
+++ b/remove-routing-components-for-transition.yml
@@ -2,9 +2,6 @@
   path: /instance_groups/name=api/jobs/name=routing-api
 
 - type: remove
-  path: /instance_groups/name=api/jobs/name=consul_agent/properties/consul/agent/services/routing-api
-
-- type: remove
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/routing_api_client
 
 - type: remove


### PR DESCRIPTION
The path for `consul_agent` no longer exists as Consul is now removed.